### PR TITLE
parameterized ipvx gateways

### DIFF
--- a/ec2.tf
+++ b/ec2.tf
@@ -62,6 +62,8 @@ resource "aws_launch_template" "instance" {
       wireguard_allowed_ips           = var.allowed_ips
       wireguard_subspace_docker_image = var.docker_image
       is_ecr_docker_image             = var.is_ecr_docker_image
+      wireguard_ipv4_gateway          = var.ipv4_gateway
+      wireguard_ipv6_gateway          = var.ipv6_gateway
       wireguard_subspace_http_host    = aws_route53_record.web.fqdn
       wireguard_endpoint_host         = aws_route53_record.endpoint.fqdn
       wireguard_backup_bucket_name    = aws_s3_bucket.backup.bucket

--- a/templates/user-data.sh.tpl
+++ b/templates/user-data.sh.tpl
@@ -124,8 +124,8 @@ docker create \
   --env SUBSPACE_LISTENPORT="51820" \
   --env SUBSPACE_IPV4_POOL="10.99.97.0/24" \
   --env SUBSPACE_IPV6_POOL="fd00::10:97:0/64" \
-  --env SUBSPACE_IPV4_GW="10.99.97.1" \
-  --env SUBSPACE_IPV6_GW="fd00::10:97:1" \
+  --env SUBSPACE_IPV4_GW="${wireguard_ipv4_gateway}" \
+  --env SUBSPACE_IPV6_GW="${wireguard_ipv6_gateway}" \
   --env SUBSPACE_IPV6_NAT_ENABLED=1 \
   --env SUBSPACE_ALLOWED_IPS="${join(",", compact(distinct(wireguard_allowed_ips)))},10.99.97.0/24" \
   ${wireguard_subspace_docker_image}

--- a/variables.tf
+++ b/variables.tf
@@ -58,3 +58,11 @@ variable "is_ecr_docker_image" {
   default = false
   type    = bool
 }
+
+variable "ipv4_gateway" {
+  default = "10.99.97.1"
+}
+
+variable "ipv6_gateway" {
+  default = "fd00::10:97:1"
+}


### PR DESCRIPTION
Option to parameterize gateways. Gateways are configured in the DNS section of Wireguard. If it is set to be the default gateway of the VPN, we risk messing up regional DNS resolutions and being geo-restricted. This PR enables the parametrization of the gateways so that a vpn can be used by international users.