### PR TITLE
Feature/optional internal url (#9)

### DIFF
--- a/route53.tf
+++ b/route53.tf
@@ -17,3 +17,14 @@ resource "aws_route53_record" "endpoint" {
 
   records = [aws_eip.this.public_ip]
 }
+
+resource "aws_route53_record" "internal" {
+  count = var.internal_url != null ? 1 : 0
+  name  = var.internal_url
+
+  type    = "A"
+  zone_id = var.zone_id
+  ttl     = 300
+
+  records = [aws_eip.this.private_ip]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -44,6 +44,11 @@ variable "web_url" {
   type = string
 }
 
+variable "internal_url" {
+  type    = string
+  default = null
+}
+
 variable "desired_instances" {
   default = 1
   type    = number


### PR DESCRIPTION
* added option to disable wireguard dns
follows https://github.com/waycarbon/subspace/pull/4

* added option to create internal URL for ssh access to vpn main instance