### PR TITLE
add cloudwatch metrics option

### DIFF
--- a/datasources.tf
+++ b/datasources.tf
@@ -13,3 +13,7 @@ data "aws_route53_zone" "target" {
 }
 
 data "aws_caller_identity" "current" {}
+
+data "aws_iam_policy" "aws_cloudwatch_agent_server_policy" {
+  arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
+}

--- a/ec2.tf
+++ b/ec2.tf
@@ -69,6 +69,7 @@ resource "aws_launch_template" "instance" {
       wireguard_subspace_http_host    = aws_route53_record.web.fqdn
       wireguard_endpoint_host         = aws_route53_record.endpoint.fqdn
       wireguard_backup_bucket_name    = aws_s3_bucket.backup.bucket
+      enable-cloudwatch-metrics       = var.enable_cloudwatch_metrics
     }
   ))
 }

--- a/iam.tf
+++ b/iam.tf
@@ -69,3 +69,8 @@ resource "aws_iam_role_policy_attachment" "this" {
   role       = aws_iam_role.this.name
 }
 
+resource "aws_iam_role_policy_attachment" "cloudwatch_agent" {
+  count      = (var.enable_cloudwatch_metrics ? 1 : 0)
+  policy_arn = data.aws_iam_policy.aws_cloudwatch_agent_server_policy.arn
+  role       = aws_iam_role.this.name
+}

--- a/variables.tf
+++ b/variables.tf
@@ -76,3 +76,9 @@ variable "disable_wireguard_dns" {
   default = false
   type    = bool
 }
+
+variable "enable_cloudwatch_metrics" {
+  default = false
+  type    = bool
+  description = "Optional: enable swap, memory and disk metrics with cloudwatch agent"
+}


### PR DESCRIPTION
- add option to enable cloudwatch metrics. This option will:
  - install, configure and start cloudwatch agent inside EC2
  - add Cloudwatch Agent Server policy to the instance profile role